### PR TITLE
Changes to compile with Xcode 12.2 on Apple Silicon for M1 MacBook Pro and macOS 11.0 SDK

### DIFF
--- a/RDM.xcodeproj/project.pbxproj
+++ b/RDM.xcodeproj/project.pbxproj
@@ -1,0 +1,271 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXFileReference section */
+		2F6832CC2592CA13009A6A07 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		2F6832CD2592CA13009A6A07 /* cmdline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmdline.h; sourceTree = "<group>"; };
+		2F6832CE2592CA13009A6A07 /* ResMenuItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ResMenuItem.mm; sourceTree = "<group>"; };
+		2F6832CF2592CA13009A6A07 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2F6832D02592CA13009A6A07 /* SRApplicationDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SRApplicationDelegate.mm; sourceTree = "<group>"; };
+		2F6832D12592CA13009A6A07 /* monitor.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = monitor.png; sourceTree = "<group>"; };
+		2F6832D22592CA13009A6A07 /* utils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = utils.mm; sourceTree = "<group>"; };
+		2F6832D32592CA13009A6A07 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		2F6832D42592CA13009A6A07 /* main.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
+		2F6832D52592CA13009A6A07 /* ResMenuItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResMenuItem.h; sourceTree = "<group>"; };
+		2F6832D72592CA13009A6A07 /* Icon_512x512.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Icon_512x512.png; sourceTree = "<group>"; };
+		2F6832D82592CA13009A6A07 /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
+		2F6832D92592CA13009A6A07 /* StatusIcon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "StatusIcon@2x.png"; sourceTree = "<group>"; };
+		2F6832DA2592CA13009A6A07 /* StatusIcon_sel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = StatusIcon_sel.png; sourceTree = "<group>"; };
+		2F6832DB2592CA13009A6A07 /* StatusIcon_sel@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "StatusIcon_sel@2x.png"; sourceTree = "<group>"; };
+		2F6832DC2592CA13009A6A07 /* StatusIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = StatusIcon.png; sourceTree = "<group>"; };
+		2F6832DD2592CA13009A6A07 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		2F6832DE2592CA13009A6A07 /* SRApplicationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SRApplicationDelegate.h; sourceTree = "<group>"; };
+		2F6832DF2592CA13009A6A07 /* cmdline.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = cmdline.mm; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		2F6832C12592C95F009A6A07 = {
+			isa = PBXGroup;
+			children = (
+				2F6832CD2592CA13009A6A07 /* cmdline.h */,
+				2F6832DF2592CA13009A6A07 /* cmdline.mm */,
+				2F6832CF2592CA13009A6A07 /* Info.plist */,
+				2F6832D42592CA13009A6A07 /* main.mm */,
+				2F6832DD2592CA13009A6A07 /* Makefile */,
+				2F6832D12592CA13009A6A07 /* monitor.png */,
+				2F6832CC2592CA13009A6A07 /* README.md */,
+				2F6832D52592CA13009A6A07 /* ResMenuItem.h */,
+				2F6832CE2592CA13009A6A07 /* ResMenuItem.mm */,
+				2F6832D62592CA13009A6A07 /* Resources */,
+				2F6832DE2592CA13009A6A07 /* SRApplicationDelegate.h */,
+				2F6832D02592CA13009A6A07 /* SRApplicationDelegate.mm */,
+				2F6832D32592CA13009A6A07 /* utils.h */,
+				2F6832D22592CA13009A6A07 /* utils.mm */,
+			);
+			sourceTree = "<group>";
+		};
+		2F6832D62592CA13009A6A07 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				2F6832D72592CA13009A6A07 /* Icon_512x512.png */,
+				2F6832D82592CA13009A6A07 /* Credits.rtf */,
+				2F6832D92592CA13009A6A07 /* StatusIcon@2x.png */,
+				2F6832DA2592CA13009A6A07 /* StatusIcon_sel.png */,
+				2F6832DB2592CA13009A6A07 /* StatusIcon_sel@2x.png */,
+				2F6832DC2592CA13009A6A07 /* StatusIcon.png */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXLegacyTarget section */
+		2F6832C62592C95F009A6A07 /* RDM */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "$(ACTION)";
+			buildConfigurationList = 2F6832C92592C95F009A6A07 /* Build configuration list for PBXLegacyTarget "RDM" */;
+			buildPhases = (
+			);
+			buildToolPath = /usr/bin/make;
+			buildWorkingDirectory = /Users/Shared/OpenSource/RDM;
+			dependencies = (
+			);
+			name = RDM;
+			passBuildSettingsInEnvironment = 1;
+			productName = RDM;
+		};
+/* End PBXLegacyTarget section */
+
+/* Begin PBXProject section */
+		2F6832C22592C95F009A6A07 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1220;
+				TargetAttributes = {
+					2F6832C62592C95F009A6A07 = {
+						CreatedOnToolsVersion = 12.2;
+					};
+				};
+			};
+			buildConfigurationList = 2F6832C52592C95F009A6A07 /* Build configuration list for PBXProject "RDM" */;
+			compatibilityVersion = "Xcode 12.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2F6832C12592C95F009A6A07;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2F6832C62592C95F009A6A07 /* RDM */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+		2F6832C72592C95F009A6A07 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+			};
+			name = Debug;
+		};
+		2F6832C82592C95F009A6A07 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+			};
+			name = Release;
+		};
+		2F6832CA2592C95F009A6A07 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEBUGGING_SYMBOLS = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = J53Z6D4K87;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		2F6832CB2592C95F009A6A07 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = J53Z6D4K87;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2F6832C52592C95F009A6A07 /* Build configuration list for PBXProject "RDM" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2F6832C72592C95F009A6A07 /* Debug */,
+				2F6832C82592C95F009A6A07 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2F6832C92592C95F009A6A07 /* Build configuration list for PBXLegacyTarget "RDM" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2F6832CA2592C95F009A6A07 /* Debug */,
+				2F6832CB2592C95F009A6A07 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2F6832C22592C95F009A6A07 /* Project object */;
+}

--- a/RDM.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RDM.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/RDM.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RDM.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SRApplicationDelegate.mm
+++ b/SRApplicationDelegate.mm
@@ -74,7 +74,7 @@
 				if(mainModeNum == j)
 				{
 					mainItem = item;
-					[item setState: NSOnState];	
+					[item setState: NSControlStateValueOn];
 				}
 				[displayMenuItems addObject: item];
 				[item release];
@@ -158,7 +158,7 @@
 				if(mainModeNum == j)
 				{
 					mainItem = item;
-					[item setState: NSOnState];	
+					[item setState: NSControlStateValueOn];
 				}
 				[displayMenuItems addObject: item];
 				[item release];
@@ -244,12 +244,13 @@
 	statusItem = [[[NSStatusBar systemStatusBar] statusItemWithLength: NSSquareStatusItemLength] retain];
 	
 	NSImage* statusImage = [NSImage imageNamed: @"StatusIcon"];
-	[statusItem setImage: statusImage];
-	[statusItem setHighlightMode: YES];
+	statusItem.button.image = statusImage;
+	[statusItem.button.cell setHighlightsBy: NSContentsCellMask];
 
-  BOOL supportsDarkMenu = !(floor(NSAppKitVersionNumber) < 1343);  // NSAppKitVersionNumber10_10
+  BOOL supportsDarkMenu = !(floor(NSAppKitVersionNumber) < 1343);
   if (supportsDarkMenu) {
-    [[statusItem image] setTemplate:YES];
+    // [[statusItem image] setTemplate:YES];
+	  [statusItem.button.image setTemplate: YES];
   }
 
 	[self refreshStatusMenu];


### PR DESCRIPTION
The Apple 13” MacBook Pro (with Apple Silicon - M1) and a Samsung C49RG9x failed to support the full 5120 x 1440 resolution (wouldn’t go past 3840x1080) despite it being supported by a late 2016 touchbar 15” MacBook Pro.

Building this in Xcode 12.2 with the necessary changes to get it compiling with modern macOS SDK and then choosing 5120 x 1440 from the RDM Status item menu was sufficient to get it working.

Adding an Xcode project for ease of building withing Xcode (not required).