### PR TITLE
Remove hardcoded ARCH statement from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ VERSION=2.2
 
 CC=llvm-g++
 PACKAGE_BUILD=/usr/bin/pkgbuild
-ARCH_FLAGS=-arch x86_64
 
 .PHONY: build
 


### PR DESCRIPTION
Remove hardcoded x86_x64 ARCH to permit native build on arm64 devices. No other changes required; CLI and GUI app both work fine so built on MacBookAir10,1 under macOS Big Sur 11.2ß.