### PR TITLE
removed arch check, compiles native for arm64 and x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ VERSION=2.2
 
 CC=llvm-g++
 PACKAGE_BUILD=/usr/bin/pkgbuild
-ARCH_FLAGS=-arch x86_64
 
 .PHONY: build
 
@@ -22,7 +21,7 @@ RDM.app: SetResX Resources Info.plist monitor.icns
 
 
 SetResX: main.o SRApplicationDelegate.o ResMenuItem.o cmdline.o utils.o 
-	$(CC) $^ -o $@ $(ARCH_FLAGS) -framework Foundation -framework ApplicationServices -framework AppKit 
+	$(CC) $^ -o $@ -framework Foundation -framework ApplicationServices -framework AppKit 
 
 
 clean:

--- a/utils.h
+++ b/utils.h
@@ -1,4 +1,5 @@
-
+#import <CoreGraphics/CGDirectDisplay.h>
+#import <CoreGraphics/CGDisplayConfiguration.h>
 
 typedef union
 {


### PR DESCRIPTION
RDM now compiles natively for arm64 (Apple M1, Apple Silicon)

Fixes https://github.com/avibrazil/RDM/issues/55