### PR TITLE
add freq flag for specifying frequency

### DIFF
--- a/cmdline.mm
+++ b/cmdline.mm
@@ -15,6 +15,7 @@ int cmdline_main(int argc, const char * argv[])
  	{
 		int width = 0;
 		int height = 0;
+		int freq = 0;
 		CGFloat scale = 0.0f;
 		int bitRes = 0;
 		int displayNo = -1;
@@ -38,6 +39,10 @@ int cmdline_main(int argc, const char * argv[])
 						case 'h':
 							i++;
 							height = atoi(argv[i]);
+							break;
+						case 'f':
+							i++;
+							freq = atoi(argv[i]);
 							break;
 						case 's':
 							i++;
@@ -87,6 +92,11 @@ int cmdline_main(int argc, const char * argv[])
 					{
 						i++;
 						height = atoi(argv[i]);
+					}
+					else if(!strcmp(&argv[i][2], "freq"))
+					{
+						i++;
+						freq = atoi(argv[i]);
 					}
 					else if(!strcmp(&argv[i][2], "scale"))
 					{
@@ -180,6 +190,8 @@ int cmdline_main(int argc, const char * argv[])
 					continue;
 				if(height && mode.derived.height != height)
 					continue;
+				if(freq && mode.derived.freq != freq)
+					continue;
 				int mBitres = (mode.derived.depth == 4) ? 32 : 16;
 				if(bitRes && mBitres != bitRes)
 					continue;
@@ -250,6 +262,10 @@ int cmdline_main(int argc, const char * argv[])
 				width = mode.derived.width;
 				height = mode.derived.height;
 			}
+			if (!freq)
+			{
+				freq = mode.derived.freq;
+			}
 			if(!scale)
 			{
 				scale = mode.derived.density;
@@ -275,6 +291,8 @@ int cmdline_main(int argc, const char * argv[])
 				if(width && mode.derived.width != width)
 					continue;
 				if(height && mode.derived.height != height)
+					continue;
+				if(freq && mode.derived.freq != freq)
 					continue;
 				int mBitres = (mode.derived.depth == 4) ? 32 : 16;
 				if(bitRes && mBitres != bitRes)

--- a/main.mm
+++ b/main.mm
@@ -20,6 +20,7 @@ int main(int argc, const char* argv[])
 		fprintf(stderr, "Commandline options\n"
 						"  --width    (-w)  Width\n"
 						"  --height   (-h)  Height\n"
+						"  --freq    (-f)  Frequency (in Hz, e.g. 30 or 60, default=not specified)\n"
 						"  --scale    (-s)  Scale (2.0 = Retina, default=current)\n"
 						"  --bits     (-b)  Color depth (default=current)\n"
 						"  --display  (-d)  Select display # (default=main)\n"


### PR DESCRIPTION
  The command line doesn't always choose the correct frequency for my display. It is better to have a way to also specify the frequency in the command line.

For example:
```sh
./SetResX -w 3008 -h 1692 -f 60
./SetResX --width 3008 -height 1692 --freq 60
```