### PR TITLE
Fix build error

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -1,4 +1,5 @@
-
+#include <stdint.h>
+#include <CoreGraphics/CoreGraphics.h>
 
 typedef union
 {


### PR DESCRIPTION
Missing include statements were causing build errors.